### PR TITLE
MappingWithdrawals

### DIFF
--- a/ExampleMappingWithdrawals.sol
+++ b/ExampleMappingWithdrawals.sol
@@ -1,0 +1,31 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.15;
+
+contract ExampleMappingWithdrawals { 
+    
+
+    mapping(address => uint) public balanceReceived;
+
+
+    function sendMoney() public payable {
+        balanceReceived[msg.sender] += msg.value;
+    }
+
+    function getBalance() public view returns (uint) {
+        return address(this).balance;
+    }
+
+    function withdrawAllMoney(address payable _to) public payable  {
+        uint balanceToSend = balanceReceived[msg.sender];
+        balanceReceived[msg.sender] = 0;
+        _to.transfer(balanceToSend);
+
+    }
+
+    function withdrawSomeMoney(address payable _to, uint _amount) public payable {
+        require(_amount <= balanceReceived[msg.sender], "not enough funds");
+        balanceReceived[msg.sender] -= _amount;
+        _to.transfer(_amount);
+    }
+}


### PR DESCRIPTION
Extend the Smart Contract and use a Mapping to track who send how much to the Smart Contract. Then only allow withdrawals for the amount deposited. So, if address 0x123... deposits 1 Ether, then address 0x123... can withdraw 1 Ether again. Nobody else. And not more.